### PR TITLE
Update Jarelllama's Scam Blocklist

### DIFF
--- a/file-hosts.sh/ad-hosts/ad-hosts-lite.sh
+++ b/file-hosts.sh/ad-hosts/ad-hosts-lite.sh
@@ -650,7 +650,7 @@ function GetData() {
         "https://v.firebog.net/hosts/neohostsbasic.txt"
         "https://raw.githubusercontent.com/matomo-org/referrer-spam-blacklist/master/spammers.txt"
         "https://malware-filter.gitlab.io/malware-filter/phishing-filter.txt"
-        "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/domains.txt"
+        "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/wildcard_domains/scams.txt"
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/ultimate.txt"
         "https://github.com/Potterli20/file/releases/download/github-hosts/ad-edge-hosts.txt"
         "https://raw.githubusercontent.com/groovy-sky/SaferDNS/main/blocklists/domains/Ultimate.Hosts.Blacklist.txt"

--- a/file-hosts.sh/ad-hosts/ad-hosts-pro.sh
+++ b/file-hosts.sh/ad-hosts/ad-hosts-pro.sh
@@ -650,7 +650,7 @@ function GetData() {
         "https://v.firebog.net/hosts/neohostsbasic.txt"
         "https://raw.githubusercontent.com/matomo-org/referrer-spam-blacklist/master/spammers.txt"
         "https://malware-filter.gitlab.io/malware-filter/phishing-filter.txt"
-        "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/domains.txt"
+        "https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/wildcard_domains/scams.txt"
         "https://raw.githubusercontent.com/hagezi/dns-blocklists/main/domains/ultimate.txt"
         "https://github.com/Potterli20/file/releases/download/github-hosts/ad-edge-hosts.txt"
         "https://raw.githubusercontent.com/groovy-sky/SaferDNS/main/blocklists/domains/Ultimate.Hosts.Blacklist.txt"


### PR DESCRIPTION
Hi! I'm the maintainer of https://github.com/jarelllama/Scam-Blocklist. I noticed you're using an outdated list of mine. If you're still keen in using my scam blocklist, here are the formats and links to them I currently offer:

| Format | Syntax |
| --- | --- |
| [Adblock Plus](https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/adblock/scams.txt) | \|\|scam.com^ |
| [Dnsmasq](https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/dnsmasq/scams.txt) | local=/scam.com/ |
| [Unbound](https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/unbound/scams.txt) | local-zone: "scam.com." always_nxdomain |
| [Wildcard Asterisk](https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/wildcard_asterisk/scams.txt) | \*.scam.com |
| [Wildcard Domains](https://raw.githubusercontent.com/jarelllama/Scam-Blocklist/main/lists/wildcard_domains/scams.txt) | scam.com |

The project has gone through major changes since the old list got decommissioned. If you'd like to read about the blocklist's updated mission, you can read more in the [README](https://github.com/jarelllama/Scam-Blocklist).